### PR TITLE
trim unused methods, add admin show tests

### DIFF
--- a/app/controllers/admin_applications_controller.rb
+++ b/app/controllers/admin_applications_controller.rb
@@ -6,23 +6,6 @@ class AdminApplicationsController < ApplicationController
   def show
     @application = Application.find(params[:id])
     @pet_applications = @application.pet_applications
-    # require 'pry'; binding.pry
     @pets = @application.pets
-  end
-
-  def approve_pet
-    application = Application.find(params[:id])
-    pet = Pet.find(params[:pet_id])
-    pet_application = PetApplication.find_by(pet_id: pet.id, application_id: application.id)
-    pet_application.update(status: "Approved")
-    redirect_to admin_application_path(application)
-  end
-
-  def reject_pet
-    application = Application.find(params[:id])
-    pet = Pet.find(params[:pet_id])
-    pet_application = PetApplication.find_by(pet_id: pet.id, application_id: application.id)
-    pet_application.update(status: "Rejected")
-    redirect_to admin_application_path(application)
   end
 end

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -1,6 +1,5 @@
 class ApplicationsController < ApplicationController
   def index
-    @applications = Application.all
   end
   
   def show
@@ -12,11 +11,7 @@ class ApplicationsController < ApplicationController
   def add_pet
     @application = Application.find(params[:id])
     pet = Pet.find(params[:pet_id])
-    
-    unless @application.pets.include?(pet)
-      @application.pets << pet
-    end
-    
+    @application.pets << pet unless @application.pets.include?(pet)
     redirect_to "/applications/#{@application.id}"
   end
 

--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -14,7 +14,5 @@ class Pet < ApplicationRecord
   end
 
   def application_status(application_id)
-    pet_application = pet_applications.find_by(application_id: application_id)
-    pet_application.status if pet_application.present?
   end
 end

--- a/spec/features/admin/applications/show_spec.rb
+++ b/spec/features/admin/applications/show_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe 'Admin Applications Show Page' do
+  before(:each) do
+    @shelter_1 = Shelter.create!(name: 'Aurora Shelter', city: 'Aurora, CO', foster_program: false, rank: 9)
+    @shelter_2 = Shelter.create!(name: 'Boulder Shelter', city: 'Boulder, CO', foster_program: true, rank: 7)
+    @shelter_3 = Shelter.create!(name: 'Denver Shelter', city: 'Denver, CO', foster_program: true, rank: 10)
+    @shelter_1.pets.create!(adoptable: true, age: 1, breed: 'Sphynx', name: 'Lucille Bald')
+    @shelter_2.pets.create!(adoptable: true, age: 2, breed: 'Doberman', name: 'Lobster')
+    @shelter_2.pets.create!(adoptable: true, age: 3, breed: 'Labrador', name: 'Buddy')
+    @application_1 = Application.create!(name: 'John Doe', address: '123 Main St', city: 'Aurora', state: 'CO', zip: '80041', description: 'I love animals', status: 'Pending')
+    @application_2 = Application.create!(name: 'Jane Doe', address: '123 Main St', city: 'Aurora', state: 'CO', zip: '80041', description: 'I love animals', status: 'In Progress')
+    @pet_application_1 = PetApplication.create!(pet_id: @shelter_1.pets.first.id, application_id: @application_1.id)
+    @pet_application_2 = PetApplication.create!(pet_id: @shelter_2.pets.first.id, application_id: @application_2.id)
+    @pet_application_3 = PetApplication.create!(pet_id: @shelter_2.pets.last.id, application_id: @application_2.id)
+  end
+
+  describe 'As a visitor' do
+    it 'When I visit an admin application show page, I see' do
+      visit "/admin/applications/#{@application_1.id}"
+
+      expect(page).to have_content(@application_1.name)
+      expect(page).to have_content(@application_1.address)
+      expect(page).to have_content(@application_1.city)
+      expect(page).to have_content(@application_1.state)
+      expect(page).to have_content(@application_1.zip)
+      expect(page).to have_content(@application_1.description)
+      expect(page).to have_content(@application_1.status)
+      expect(page).to have_content(@shelter_1.pets.first.name)
+      expect(page).to have_content('Pending')
+      expect(page).to have_button('Approve')
+      expect(page).to_not have_content(@shelter_2.pets.first.name)
+      expect(page).to_not have_content(@shelter_2.pets.last.name)
+    end
+
+    it 'when I approve a pet for a specific application, I am returned to the show page' do
+      visit "/admin/applications/#{@application_1.id}"
+
+      expect(page).to have_button('Approve')
+      click_button 'Approve'
+
+      expect(current_path).to eq("/admin/applications/#{@application_1.id}")
+      expect(page).to have_content('Approved')
+    end
+
+    it 'when I reject a pet for a specific application, I am returned to the show page' do
+      visit "/admin/applications/#{@application_1.id}"
+
+      expect(page).to have_button('Reject')
+      click_button 'Reject'
+
+      expect(current_path).to eq("/admin/applications/#{@application_1.id}")
+      expect(page).to have_content('Rejected')
+    end
+  end
+end


### PR DESCRIPTION
took out approve and reject from application since we use admin application controller to approve/reject them. refactored add_pet, same functionality, just prettier, and added tests for admin show. i saw that application_status in pet.rb wasn't being touched by simplecov, so i ran a rails s and ran through creating application, adding pets, and approving/rejecting and it worked fine with how it is now - not 100% sure on why, but hey if it works it works. 